### PR TITLE
Correct column names in the tns_search function

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -44,9 +44,9 @@ begin
     tns.section_num,
     tns.section_url,
     tns.chunk_num,
-    tns.text,
-    tns.length,
-    tns.tokens,
+    tns.content,
+    tns.content_length,
+    tns.content_tokens,
     1 - (tns.embedding <=> query_embedding) as similarity
   from tns
   where 1 - (tns.embedding <=> query_embedding) > similarity_threshold


### PR DESCRIPTION
I tried to run this locally and ran into column name errors which I fixed.